### PR TITLE
Fixed isNodeSelected() return

### DIFF
--- a/src/select_node_handler.coffee
+++ b/src/select_node_handler.coffee
@@ -42,7 +42,7 @@ class SelectNodeHandler
 
     isNodeSelected: (node) ->
         if node.id
-            return @selected_nodes[node.id]
+            return !!@selected_nodes[node.id]
         else if @selected_single_node
             return @selected_single_node.element == node.element
         else


### PR DESCRIPTION
This lookup could return undefined if the node with the given ID isn't in the selected_nodes map. In this case, it should return false.
